### PR TITLE
Feature/const char in the API

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -14,10 +14,10 @@
 #include "utils.h"
 
 s_influxdb_client
-*influxdb_client_new(char *host,
-                     char *username,
-                     char *password,
-                     char *database,
+*influxdb_client_new(const char *host,
+                     const char *username,
+                     const char *password,
+                     const char *database,
                      char ssl)
 {
     s_influxdb_client *client = malloc(sizeof (s_influxdb_client));
@@ -39,9 +39,9 @@ int
 influxdb_client_get_url_with_credential(s_influxdb_client *client,
                                         char (*buffer)[],
                                         size_t size,
-                                        char *path,
-                                        char *username,
-                                        char *password)
+                                        const char *path,
+                                        const char *username,
+                                        const char *password)
 {
     char *username_enc = curl_easy_escape(NULL, username, 0);
     char *password_enc = curl_easy_escape(NULL, password, 0);
@@ -107,8 +107,8 @@ influxdb_client_write_data(char *buf,
  * Low level function performing real HTTP request
  */
 int
-influxdb_client_curl(char *url,
-                     char *reqtype,
+influxdb_client_curl(const char *url,
+                     const char *reqtype,
                      json_object *body,
                      char **response)
 {
@@ -142,7 +142,7 @@ influxdb_client_curl(char *url,
 
 int
 influxdb_client_delete(s_influxdb_client *client,
-                       char *path,
+                       const char *path,
                        json_object *body)
 {
     char url[INFLUXDB_URL_MAX_SIZE];
@@ -153,7 +153,7 @@ influxdb_client_delete(s_influxdb_client *client,
 }
 
 int
-influxdb_client_get(s_influxdb_client *client, char *path, json_object **res)
+influxdb_client_get(s_influxdb_client *client, const char *path, json_object **res)
 {
     int status;
     char url[INFLUXDB_URL_MAX_SIZE];
@@ -173,7 +173,7 @@ influxdb_client_get(s_influxdb_client *client, char *path, json_object **res)
 
 int
 influxdb_client_post(s_influxdb_client *client,
-                     char *path,
+                     const char *path,
                      json_object *body,
                      json_object **res)
 {
@@ -195,7 +195,7 @@ influxdb_client_post(s_influxdb_client *client,
 
 size_t
 influxdb_client_list_something(s_influxdb_client *client,
-                               char *path,
+                               const char *path,
                                void ***list,
                                influxdb_client_object_extract extractor)
 {

--- a/src/client.h
+++ b/src/client.h
@@ -36,10 +36,10 @@ typedef struct influxdb_client {
  *
  * \return An initialized client struct
  */
-s_influxdb_client *influxdb_client_new(char *host,
-                                       char *username,
-                                       char *password,
-                                       char *database,
+s_influxdb_client *influxdb_client_new(const char *host,
+                                       const char *username,
+                                       const char *password,
+                                       const char *database,
                                        char ssl);
 
 /**
@@ -56,7 +56,7 @@ void influxdb_client_free(s_influxdb_client *client);
  * \return HTTP status code or CURLcode (if < 100)
  */
 int influxdb_client_delete(s_influxdb_client *client,
-                           char              *path,
+                           const char        *path,
                            json_object       *body);
 
 /**
@@ -68,7 +68,7 @@ int influxdb_client_delete(s_influxdb_client *client,
  * \return HTTP status code or CURLcode (if < 100)
  */
 int influxdb_client_get(s_influxdb_client *client,
-                        char              *path,
+                        const char          *path,
                         json_object       **res);
 
 /**
@@ -81,7 +81,7 @@ int influxdb_client_get(s_influxdb_client *client,
  * \return HTTP status code or CURLcode (if < 100)
  */
 int influxdb_client_post(s_influxdb_client *client,
-                         char              *path,
+                         const char        *path,
                          json_object       *body,
                          json_object       **res);
 
@@ -96,7 +96,7 @@ typedef void *(*influxdb_client_object_extract)(json_object *obj);
  * \return The list size
  */
 size_t influxdb_client_list_something(s_influxdb_client             *client,
-                                     char                           *path,
+                                     const char                     *path,
                                      void                           ***list,
                                      influxdb_client_object_extract extractor);
 

--- a/src/cluster_admin.c
+++ b/src/cluster_admin.c
@@ -13,8 +13,8 @@
 #include "utils.h"
 
 int influxdb_create_cluster_admin(s_influxdb_client *client,
-                                  char *name,
-                                  char *password)
+                                  const char *name,
+                                  const char *password)
 {
     int c;
     json_object *jo = json_object_new_object();
@@ -29,7 +29,8 @@ int influxdb_create_cluster_admin(s_influxdb_client *client,
 }
 
 int influxdb_update_cluster_admin(s_influxdb_client *client,
-                                  char *name, char *password)
+                                  const char *name,
+                                  const char *password)
 {
     int c;
     char path[INFLUXDB_URL_MAX_SIZE];
@@ -49,14 +50,14 @@ int influxdb_update_cluster_admin(s_influxdb_client *client,
 
 int
 influxdb_change_cluster_admin_password(s_influxdb_client *client,
-                                       char *name,
-                                       char *newPassword)
+                                       const char *name,
+                                       const char *newPassword)
 {
     return influxdb_update_cluster_admin(client, name, newPassword);
 }
 
 int influxdb_delete_cluster_admin(s_influxdb_client *client,
-                                  char *name)
+                                  const char *name)
 {
     int c;
     char path[INFLUXDB_URL_MAX_SIZE];

--- a/src/cluster_admin.h
+++ b/src/cluster_admin.h
@@ -21,8 +21,8 @@
  * \return HTTP status code or CURLcode (if < 100)
  */
 int influxdb_create_cluster_admin(s_influxdb_client *client,
-                                  char              *name,
-                                  char              *password);
+                                  const char        *name,
+                                  const char        *password);
 
 /**
  * Update a cluster admin password
@@ -33,11 +33,11 @@ int influxdb_create_cluster_admin(s_influxdb_client *client,
  * \return HTTP status code or CURLcode (if < 100)
  */
 int influxdb_update_cluster_admin(s_influxdb_client *client,
-                                  char              *name,
-                                  char              *newPassword);
+                                  const char        *name,
+                                  const char        *newPassword);
 int influxdb_change_cluster_admin_password(s_influxdb_client *client,
-                                           char              *name,
-                                           char              *newPassword);
+                                           const char        *name,
+                                           const char        *newPassword);
 
 /**
  * Remove a cluster admin
@@ -47,7 +47,7 @@ int influxdb_change_cluster_admin_password(s_influxdb_client *client,
  * \return HTTP status code or CURLcode (if < 100)
  */
 int influxdb_delete_cluster_admin(s_influxdb_client *client,
-                                  char              *name);
+                                  const char        *name);
 
 /**
  * List existing cluster admins
@@ -57,6 +57,6 @@ int influxdb_delete_cluster_admin(s_influxdb_client *client,
  * \return The number of cluster admins
  */
 size_t influxdb_get_cluster_admin_list(s_influxdb_client *client,
-                                       char             ***cluster_admin_list);
+                                       char        ***cluster_admin_list);
 
 #endif /* !CLUSTER_ADMIN_H_ */

--- a/src/database.c
+++ b/src/database.c
@@ -13,7 +13,7 @@
 #include "utils.h"
 
 int
-influxdb_create_database(s_influxdb_client *client, char *database_name)
+influxdb_create_database(s_influxdb_client *client, const char *database_name)
 {
     int c;
     json_object *jo = json_object_new_object();
@@ -27,7 +27,7 @@ influxdb_create_database(s_influxdb_client *client, char *database_name)
 }
 
 int
-influxdb_delete_database(s_influxdb_client *client, char *database_name)
+influxdb_delete_database(s_influxdb_client *client, const char *database_name)
 {
     int c;
     char path[INFLUXDB_URL_MAX_SIZE];

--- a/src/database.h
+++ b/src/database.h
@@ -20,7 +20,7 @@
  * \return HTTP status code or CURLcode (if < 100)
  */
 int influxdb_create_database(s_influxdb_client *client,
-                             char              *database_name);
+                             const char        *database_name);
 
 /**
  * Delete an existing database
@@ -30,7 +30,7 @@ int influxdb_create_database(s_influxdb_client *client,
  * \return HTTP status code or CURLcode (if < 100)
  */
 int influxdb_delete_database(s_influxdb_client *client,
-                             char              *database_name);
+                             const char        *database_name);
 
 /**
  * List existing databases

--- a/src/database_user.c
+++ b/src/database_user.c
@@ -13,9 +13,12 @@
 #include "utils.h"
 
 int
-influxdb_create_database_user(s_influxdb_client *client, char *database,
-                              char *name, char *password,
-                              char *r_perm, char *w_perm)
+influxdb_create_database_user(s_influxdb_client *client,
+                              const char *database,
+                              const char *name,
+                              const char *password,
+                              const char *r_perm,
+                              const char *w_perm)
 {
     int c;
     char path[INFLUXDB_URL_MAX_SIZE];
@@ -38,9 +41,13 @@ influxdb_create_database_user(s_influxdb_client *client, char *database,
 }
 
 int
-influxdb_change_database_user_common(s_influxdb_client *client, char *database,
-                                   char *name, char *password, char isAdmin,
-                                   char *r_perm, char *w_perm)
+influxdb_change_database_user_common(s_influxdb_client *client,
+                                    const char *database,
+                                    const char *name,
+                                    const char *password,
+                                    char isAdmin,
+                                    const char *r_perm,
+                                    const char *w_perm)
 {
     int c;
     char path[INFLUXDB_URL_MAX_SIZE];
@@ -68,9 +75,13 @@ influxdb_change_database_user_common(s_influxdb_client *client, char *database,
 }
 
 int
-influxdb_change_database_user(s_influxdb_client *client, char *database,
-                              char *name, char *newPassword, char isAdmin,
-                              char *new_r_perm, char *new_w_perm)
+influxdb_change_database_user(s_influxdb_client *client,
+                              const char *database,
+                              const char *name,
+                              const char *newPassword,
+                              char isAdmin,
+                              const char *new_r_perm,
+                              const char *new_w_perm)
 {
     return influxdb_change_database_user_common(client, database, name,
                                                 newPassword, isAdmin,
@@ -79,32 +90,40 @@ influxdb_change_database_user(s_influxdb_client *client, char *database,
 
 
 int
-influxdb_update_database_user(s_influxdb_client *client, char *database,
-                              char *name, char *password)
+influxdb_update_database_user(s_influxdb_client *client,
+                              const char *database,
+                              const char *name,
+                              const char *password)
 {
     return influxdb_change_database_user_common(client, database, name,
                                                 password, -1, NULL, NULL);
 }
 
 int influxdb_update_database_user_permissions(s_influxdb_client *client,
-                                              char *database, char *name,
-                                              char *r_perm, char *w_perm)
+                                              const char *database,
+                                              const char *name,
+                                              const char *r_perm,
+                                              const char *w_perm)
 {
     return influxdb_change_database_user_common(client, database, name,
                                                 NULL, -1, r_perm, w_perm);
 }
 
-int influxdb_alter_database_privilege(s_influxdb_client *client, char *database,
-                                      char *name, char isAdmin,
-                                      char *r_perm, char *w_perm)
+int influxdb_alter_database_privilege(s_influxdb_client *client,
+                                      const char *database,
+                                      const char *name,
+                                      char isAdmin,
+                                      const char *r_perm,
+                                      const char *w_perm)
 {
     return influxdb_change_database_user_common(client, database, name,
                                                 NULL, isAdmin, r_perm, w_perm);
 }
 
 int
-influxdb_delete_database_user(s_influxdb_client *client, char *database,
-                              char *name)
+influxdb_delete_database_user(s_influxdb_client *client,
+                              const char *database,
+                              const char *name)
 {
     int c;
     char path[INFLUXDB_URL_MAX_SIZE];
@@ -135,7 +154,8 @@ void
 }
 
 size_t
-influxdb_get_database_user_list(s_influxdb_client *client, char *database,
+influxdb_get_database_user_list(s_influxdb_client *client,
+                                const char *database,
                                 char ***users_list)
 {
     char path[INFLUXDB_URL_MAX_SIZE];

--- a/src/database_user.h
+++ b/src/database_user.h
@@ -24,11 +24,11 @@
  * \return HTTP status code or CURLcode (if < 100)
  */
 int influxdb_create_database_user(s_influxdb_client *client,
-                                  char              *database,
-                                  char              *name,
-                                  char              *password,
-                                  char              *r_perm,
-                                  char              *w_perm);
+                                  const char        *database,
+                                  const char        *name,
+                                  const char        *password,
+                                  const char        *r_perm,
+                                  const char        *w_perm);
 
 /**
  * Change the user password, adming flag and optionally permissions
@@ -39,12 +39,12 @@ int influxdb_create_database_user(s_influxdb_client *client,
  * \return HTTP status code or CURLcode (if < 100)
  */
 int influxdb_change_database_user(s_influxdb_client *client,
-                                  char              *database,
-                                  char              *name,
-                                  char              *newPassword,
+                                  const char        *database,
+                                  const char        *name,
+                                  const char        *newPassword,
                                   char              isAdmin,
-                                  char              *new_r_perm,
-                                  char              *new_w_perm);
+                                  const char        *new_r_perm,
+                                  const char        *new_w_perm);
 
 /**
  * Update some user properties
@@ -55,9 +55,9 @@ int influxdb_change_database_user(s_influxdb_client *client,
  * \return HTTP status code or CURLcode (if < 100)
  */
 int influxdb_update_database_user(s_influxdb_client *client,
-                                  char              *database,
-                                  char              *name,
-                                  char              *newPassword);
+                                  const char        *database,
+                                  const char        *name,
+                                  const char        *newPassword);
 
 /**
  * Update user permissions on database
@@ -70,10 +70,10 @@ int influxdb_update_database_user(s_influxdb_client *client,
  * \return HTTP status code or CURLcode (if < 100)
  */
 int influxdb_update_database_user_permissions(s_influxdb_client *client,
-                                              char              *database,
-                                              char              *name,
-                                              char              *new_r_perm,
-                                              char              *new_w_perm);
+                                              const char        *database,
+                                              const char        *name,
+                                              const char        *new_r_perm,
+                                              const char        *new_w_perm);
 
 /**
  * Remove an user
@@ -83,8 +83,8 @@ int influxdb_update_database_user_permissions(s_influxdb_client *client,
  * \return HTTP status code or CURLcode (if < 100)
  */
 int influxdb_delete_database_user(s_influxdb_client *client,
-                                  char              *database,
-                                  char              *name);
+                                  const char        *database,
+                                  const char        *name);
 
 /**
  * List existing users on database
@@ -95,7 +95,7 @@ int influxdb_delete_database_user(s_influxdb_client *client,
  * \return The number of users
  */
 size_t influxdb_get_database_user_list(s_influxdb_client *client,
-                                       char              *database,
+                                       const char        *database,
                                        char              ***users_list);
 
 /**
@@ -110,10 +110,10 @@ size_t influxdb_get_database_user_list(s_influxdb_client *client,
  * \return HTTP status code or CURLcode (if < 100)
  */
 int influxdb_alter_database_privilege(s_influxdb_client *client,
-                                      char              *database,
-                                      char              *name,
+                                      const char        *database,
+                                      const char        *name,
                                       char              isAdmin,
-                                      char              *new_r_perm,
-                                      char              *new_w_perm);
+                                      const char        *new_r_perm,
+                                      const char        *new_w_perm);
 
 #endif /* !DATABASE_USER_H_ */

--- a/src/query.c
+++ b/src/query.c
@@ -83,7 +83,7 @@ influxdb_write_series_with_time_precision(s_influxdb_client *client,
 
 int
 influxdb_query(s_influxdb_client *client,
-               char *query,
+               const char *query,
                e_influxdb_time_precision time_precision,
                s_influxdb_series ***response,
                size_t *response_size)

--- a/src/query.h
+++ b/src/query.h
@@ -79,7 +79,7 @@ int influxdb_write_series_with_time_precision(s_influxdb_client *client,
  * \return HTTP status code or CURLcode (if < 100)
  */
 int influxdb_query(s_influxdb_client *client,
-                   char *query,
+                   const char *query,
                    e_influxdb_time_precision time_precision,
                    s_influxdb_series ***response,
                    size_t *response_size);

--- a/src/series.c
+++ b/src/series.c
@@ -30,7 +30,7 @@ size_t influxdb_series_get_points(s_influxdb_series *series, char ****list)
 }
 
 char
-influxdb_series_set_name(s_influxdb_series *series, char *name)
+influxdb_series_set_name(s_influxdb_series *series, const char *name)
 {
     free(series->name);
     series->name = influxdb_strdup(name);
@@ -49,7 +49,7 @@ char
 }
 
 char
-influxdb_series_add_colums(s_influxdb_series *series, char *name)
+influxdb_series_add_colums(s_influxdb_series *series,const char *name)
 {
     if (series->columns_length == 0) {
         series->columns = malloc(sizeof (char *) * INFLUXDB_SERIES_STEP);

--- a/src/series.h
+++ b/src/series.h
@@ -45,7 +45,7 @@ size_t influxdb_series_get_points(s_influxdb_series *series, char ****list);
 /**
  * Define the serie name
  */
-char influxdb_series_set_name(s_influxdb_series *series, char *name);
+char influxdb_series_set_name(s_influxdb_series *series, const char *name);
 
 /**
  * Define the columns list
@@ -57,7 +57,7 @@ char **influxdb_series_set_columns(s_influxdb_series *series,
 /**
  * Add a new column
  */
-char influxdb_series_add_colums(s_influxdb_series *series, char *name);
+char influxdb_series_add_colums(s_influxdb_series *series, const char *name);
 
 /**
  * Define the points matrix


### PR DESCRIPTION
This allows us to work better withC++ (std::string) strings. This way
we could pass directly (after calling .c_str()) C++ std:strings to
InfluxDb C API functions. Currently I'm doing something like:

```c
char *c_str = new char[cpp_std_string.length() + 1];
strcpy(c_str, cpp_std_string.c_str());

/* After that */

influxdb_api_function(c_str, ...);
```
With this change I'll be able to do:

```c++
influxdb_api_function(cpp_std_string.c_str(), ...);
```

And after I can call infludb_function(cpp_std_string.c_str(), ...);

